### PR TITLE
Start adding timers

### DIFF
--- a/main/pcf8563.c
+++ b/main/pcf8563.c
@@ -29,7 +29,7 @@ esp_err_t pcf8563_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio
     dev->sda_io_num = sda_gpio;
     dev->scl_io_num = scl_gpio;
     dev->clk_speed = I2C_FREQ_HZ;
-    return i2c_master_init(port, sda_gpio, scl_gpio); //, dev->clk_speed
+    return i2c_master_init(port, sda_gpio, scl_gpio, dev->clk_speed);
 }
 
 esp_err_t pcf8563_reset(i2c_dev_t *dev)
@@ -126,18 +126,6 @@ void pcf8563_set_timer(i2c_dev_t *dev, uint8_t freq, uint8_t count) {
     check_err(res, timer2, 1, "pcf8563_set_timer write_reg 0x0F failed");
 }
 
-esp_err_t pcf8563_set_clock_out(i2c_dev_t *dev, uint8_t freq) {
-    freq &= 0b10000011;
-    uint8_t _data[1];
-    _data[0] = freq;
-    esp_err_t res = i2c_dev_write_reg(dev, PCF8563_SQW_REG,  &_data, 1);
-    check_err(res, _data, 1, "pcf8563_set_clock_out write_reg 0x0D failed");
-    return res;
-}
-
-/**
- * @deprecated use pcf8563_set_timer function
- */
 void pcf8563_enable_timer(i2c_dev_t *dev) {
     uint8_t _data[1];
     esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
@@ -172,6 +160,22 @@ bool pcf8563_is_timer_active(i2c_dev_t *dev) {
 }
 
 // Set and enable clock out
+esp_err_t pcf8563_set_clock_out(i2c_dev_t *dev, uint8_t freq) {
+    freq &= 0b10000011;
+    uint8_t _data[1];
+    _data[0] = freq;
+    esp_err_t res = i2c_dev_write_reg(dev, PCF8563_SQW_REG,  &_data, 1);
+    check_err(res, _data, 1, "pcf8563_set_clock_out write_reg 0x0D failed");
+    return res;
+}
+
+/**
+ * @deprecated use  pcf8563_set_clock_out this will not pass QA
+ * 
+ * @param dev 
+ * @param freq 
+ * @return esp_err_t 
+ */
 esp_err_t pcf8563_set_clock_out2(i2c_dev_t *dev, uint8_t freq) {
     if (freq > PCF8563_CLK_1_div_60HZ) return false;
     uint8_t _data[1];

--- a/main/pcf8563.c
+++ b/main/pcf8563.c
@@ -29,7 +29,7 @@ esp_err_t pcf8563_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio
     dev->sda_io_num = sda_gpio;
     dev->scl_io_num = scl_gpio;
     dev->clk_speed = I2C_FREQ_HZ;
-    return i2c_master_init(port, sda_gpio, scl_gpio, dev->clk_speed);
+    return i2c_master_init(port, sda_gpio, scl_gpio); //, dev->clk_speed
 }
 
 esp_err_t pcf8563_reset(i2c_dev_t *dev)
@@ -74,7 +74,7 @@ esp_err_t pcf8563_get_time(i2c_dev_t *dev, struct tm *time)
         if (res != ESP_OK) return res;
 
     /* convert to unix time structure */
-    ESP_LOGD("", "data=%02x %02x %02x %02x %02x %02x %02x",
+    ESP_LOGD("pcf8563_get_time", "data=%02x %02x %02x %02x %02x %02x %02x",
                  data[0],data[1],data[2],data[3],data[4],data[5],data[6]);
     time->tm_sec = bcd2dec(data[0] & 0x7F);
     time->tm_min = bcd2dec(data[1] & 0x7F);
@@ -111,54 +111,138 @@ uint8_t pcf8563_get_flags(i2c_dev_t *dev) {
 	return flags[0] & 0x0C;	//Mask unnecessary bits
 }
 
-void pcf8563_set_timer(i2c_dev_t *dev, uint8_t val, uint8_t freq) {
-    uint8_t _data[2];
-    esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
-    check_err(res, _data, 1, "pcf8563_set_timer read_reg ADDR_STATUS2 failed");
-
+// Based on https://github.com/HausnerR/AVR-PCF8563/blob/master/PCF8563.c
+// Set timer masks the input freq and will also enable timer
+void pcf8563_set_timer(i2c_dev_t *dev, uint8_t freq, uint8_t count) {
     uint8_t timer1[1];
     uint8_t timer2[1];
-    res = i2c_dev_read_reg(dev, PCF8563_TIMER1_REG, &timer1, 1);
-    check_err(res, timer1, 1, "pcf8563_set_timer read_reg TIMER1_REG failed");
+    freq &= 0b10000011;
+    timer1[0] = freq;
+    timer2[0] = count;
 
-    // Add interrupt
-    _data[0] |= 1 << 4;
-
-    timer1[0] |= (freq &  PCF8563_TIMER_TD10);
-    timer2[0] = val;
-
-    res = i2c_dev_write_reg(dev, PCF8563_ADDR_STATUS2,  &_data, 1);
-    check_err(res, _data, 1, "pcf8563_set_timer write_reg ADDR_STATUS2 failed");
-    res = i2c_dev_write_reg(dev, PCF8563_TIMER1_REG,  &timer1, 1);
-    check_err(res, timer1, 1, "pcf8563_set_timer write_reg TIMER1_REG failed");
+    esp_err_t res = i2c_dev_write_reg(dev, PCF8563_TIMER1_REG,  &timer1, 1);
+    check_err(res, timer1, 1, "pcf8563_set_timer write_reg 0x0E failed");
     res = i2c_dev_write_reg(dev, PCF8563_TIMER2_REG,  &timer2, 1);
-    check_err(res, timer2, 1, "pcf8563_set_timer write_reg TIMER2_REG failed");
+    check_err(res, timer2, 1, "pcf8563_set_timer write_reg 0x0F failed");
 }
 
+esp_err_t pcf8563_set_clock_out(i2c_dev_t *dev, uint8_t freq) {
+    freq &= 0b10000011;
+    uint8_t _data[1];
+    _data[0] = freq;
+    esp_err_t res = i2c_dev_write_reg(dev, PCF8563_SQW_REG,  &_data, 1);
+    check_err(res, _data, 1, "pcf8563_set_clock_out write_reg 0x0D failed");
+    return res;
+}
+
+/**
+ * @deprecated use pcf8563_set_timer function
+ */
 void pcf8563_enable_timer(i2c_dev_t *dev) {
     uint8_t _data[1];
     esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
-    check_err(res, _data, 1, "pcf8563_enable_timer read_reg ADDR_STATUS2 failed");
+    check_err(res, _data, 1, "pcf8563_enable_timer read_reg 0x01 failed");
 
     uint8_t timer1[1];
     res = i2c_dev_read_reg(dev, PCF8563_TIMER1_REG, &timer1, 1);
-    check_err(res, timer1, 1, "pcf8563_enable_timer read_reg TIMER1_REG failed");
+    check_err(res, timer1, 1, "pcf8563_enable_timer read_reg 0x0E failed");
 
     _data[0] &= ~PCF8563_TIMER_TF;
     _data[0] |= (PCF8563_ALARM_AF | PCF8563_TIMER_TIE);
     timer1[0] |= PCF8563_TIMER_TE;
     res = i2c_dev_write_reg(dev, PCF8563_ADDR_STATUS2,  &_data, 1);
-    check_err(res, _data, 1, "pcf8563_enable_timer write_reg ADDR_STATUS2 failed");
+    check_err(res, _data, 1, "pcf8563_enable_timer write_reg 0x01 failed");
     res = i2c_dev_write_reg(dev, PCF8563_TIMER1_REG,  &timer1, 1);
-    check_err(res, timer1, 1, "pcf8563_enable_timer write_reg TIMER1_REG failed");
+    check_err(res, timer1, 1, "pcf8563_enable_timer write_reg 0x0E failed");
 }
 
-esp_err_t pcf8563_enable_clock(i2c_dev_t *dev, uint8_t freq) {
-    if (freq >= PCF8563_CLK_MAX) return false;
+uint8_t pcf8563_get_timer(i2c_dev_t *dev) {
+    uint8_t _data[1];
+    esp_err_t res = i2c_dev_read_reg(dev, PCF8563_TIMER2_REG, &_data, 1);
+    check_err(res, _data, 1, "pcf8563_get_timer read_reg 0x0F failed");
+    return _data[0];
+}
+
+// Return true if timer is active
+bool pcf8563_is_timer_active(i2c_dev_t *dev) {
+    uint8_t _data[1];
+    esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
+    check_err(res, _data, 1, "pcf8563_is_timer_active read_reg 0x01 failed");
+    return (bool) _data[0] & PCF8563_TIMER_TF;
+}
+
+// Set and enable clock out
+esp_err_t pcf8563_set_clock_out2(i2c_dev_t *dev, uint8_t freq) {
+    if (freq > PCF8563_CLK_1_div_60HZ) return false;
     uint8_t _data[1];
     _data[0] = freq | PCF8563_CLK_ENABLE;
 
     esp_err_t res = i2c_dev_write_reg(dev, PCF8563_SQW_REG,  &_data, 1);
-    check_err(res, _data, 1, "pcf8563_enable_clock write_reg PCF8563_SQW_REG failed");
+    check_err(res, _data, 1, "pcf8563_enable_clock write_reg 0x0D failed");
+    return res;
+}
+
+esp_err_t pcf8563_set_alarm(i2c_dev_t *dev, struct tm *time)
+{
+    CHECK_ARG(dev);
+    CHECK_ARG(time);
+    // Minimal validation time struct
+    if (time->tm_hour > 23 || time->tm_min > 60 || time->tm_sec > 60) {
+        ESP_LOGE("pcf8563_set_alarm", "time struct not valid HH:%d MM:%d SEC:%d",
+        time->tm_hour, time->tm_min, time->tm_sec);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    uint8_t data[7];
+    /* time/date data */
+    data[0] = dec2bcd(time->tm_sec);
+    data[1] = dec2bcd(time->tm_min);
+    data[2] = dec2bcd(time->tm_hour);
+    data[3] = dec2bcd(time->tm_mday);
+    data[4] = dec2bcd(time->tm_wday);		// tm_wday is 0 to 6
+    data[5] = dec2bcd(time->tm_mon + 1);	// tm_mon is 0 to 11
+    data[6] = dec2bcd(time->tm_year - 2000);
+
+    esp_err_t res = i2c_dev_write_reg(dev, PCF8563_ALRM_MIN_REG, data, 7);
+    check_err(res, data, 7, "pcf8563_set_alarm write_reg 0x09 failed");
+    return res;
+}
+
+esp_err_t pcf8563_enable_alarm(i2c_dev_t *dev) {
+    uint8_t _data[1];
+    esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
+    check_err(res, _data, 1, "pcf8563_enable_alarm read_reg 0x01 failed");
+
+    _data[0] &= ~PCF8563_ALARM_AF;
+    _data[0] |= (PCF8563_TIMER_TF | PCF8563_ALARM_AIE);
+
+    res = i2c_dev_write_reg(dev, PCF8563_ADDR_STATUS2, _data, 1);
+    check_err(res, _data, 1, "pcf8563_set_alarm write_reg 0x01 failed");
+    return res;
+}
+
+esp_err_t pcf8563_disable_alarm(i2c_dev_t *dev) {
+    uint8_t _data[1];
+    esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
+    check_err(res, _data, 1, "pcf8563_enable_alarm read_reg 0x01 failed");
+
+    _data[0] &= ~(PCF8563_ALARM_AF | PCF8563_ALARM_AIE);
+    _data[0] |= PCF8563_TIMER_TF;
+
+    res = i2c_dev_write_reg(dev, PCF8563_ADDR_STATUS2, _data, 1);
+    check_err(res, _data, 1, "pcf8563_set_alarm write_reg 0x01 failed");
+    return res;
+}
+
+esp_err_t pcf8563_reset_alarm(i2c_dev_t *dev) {
+    uint8_t _data[1];
+    esp_err_t res = i2c_dev_read_reg(dev, PCF8563_ADDR_STATUS2, &_data, 1);
+    check_err(res, _data, 1, "pcf8563_enable_alarm read_reg 0x01 failed");
+
+    _data[0] &= ~(PCF8563_ALARM_AF);
+    _data[0] |= PCF8563_TIMER_TF;
+
+    res = i2c_dev_write_reg(dev, PCF8563_ADDR_STATUS2, _data, 1);
+    check_err(res, _data, 1, "pcf8563_set_alarm write_reg 0x01 failed");
     return res;
 }

--- a/main/pcf8563.h
+++ b/main/pcf8563.h
@@ -48,20 +48,13 @@ extern "C" {
 #define PCF8563_ALARM_ENABLE    (0x80)
 #define PCF8563_CLK_ENABLE      (0x80)
 
-// Real-time  8.8.1 Register Timer_control
+// 8.8.1 Register Timer_control
 enum {
     PCF8563_CLK_4096HZ,
     PCF8563_CLK_64HZ,     // Giving 30 per second
     PCF8563_CLK_1HZ,       // per Second
     PCF8563_CLK_1_div_60HZ // timer Minute
 };
-// Original
-/* enum {
-    PCF8563_CLK_32_768KHZ,
-    PCF8563_CLK_1024KHZ,
-    PCF8563_CLK_32HZ,
-    PCF8563_CLK_1HZ
-}; */
 
 uint8_t bcd2dec(uint8_t val);
 uint8_t dec2bcd(uint8_t val);
@@ -69,7 +62,7 @@ esp_err_t pcf8563_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio
 esp_err_t pcf8563_reset(i2c_dev_t *dev);
 esp_err_t pcf8563_set_time(i2c_dev_t *dev, struct tm *time);
 esp_err_t pcf8563_get_time(i2c_dev_t *dev, struct tm *time);
-// New functions: Need additional testing
+// New functions: Need additional testing specially the pcf8563_set_alarm
 uint8_t check_err(esp_err_t res, uint8_t * data, uint16_t size, char * op);
 
 uint8_t pcf8563_get_flags(i2c_dev_t *dev);

--- a/main/pcf8563.h
+++ b/main/pcf8563.h
@@ -73,8 +73,9 @@ esp_err_t pcf8563_set_clock_out2(i2c_dev_t *dev, uint8_t freq); // Different ver
 
 uint8_t pcf8563_get_timer(i2c_dev_t *dev);
 bool pcf8563_is_timer_active(i2c_dev_t *dev);
+// ALARM
 esp_err_t pcf8563_set_alarm(i2c_dev_t *dev, struct tm *time);
-esp_err_t pcf8563_enable_alarm(i2c_dev_t *dev);
+// Did not try this two they might go away in further reviews
 esp_err_t pcf8563_disable_alarm(i2c_dev_t *dev);
 esp_err_t pcf8563_reset_alarm(i2c_dev_t *dev);
 

--- a/main/pcf8563.h
+++ b/main/pcf8563.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// DATASHEET: https://www.nxp.com/docs/en/data-sheet/PCF8563.pdf
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,7 +13,7 @@ extern "C" {
 #include "i2cdev.h"
 
 #define PCF8563_ADDR 0x51 //!< I2C address
-// In () https://github.com/lewisxhe/PCF8563_Library/blob/master/src/pcf8563.h
+// In https://github.com/lewisxhe/PCF8563_Library/blob/master/src/pcf8563.h
 #define PCF8563_ADDR_STATUS1 0x00
 #define PCF8563_ADDR_STATUS2 0x01
 #define PCF8563_SEC_REG      0x02
@@ -46,13 +48,20 @@ extern "C" {
 #define PCF8563_ALARM_ENABLE    (0x80)
 #define PCF8563_CLK_ENABLE      (0x80)
 
+// Real-time  8.8.1 Register Timer_control
 enum {
+    PCF8563_CLK_4096HZ,
+    PCF8563_CLK_64HZ,     // Giving 30 per second
+    PCF8563_CLK_1HZ,       // per Second
+    PCF8563_CLK_1_div_60HZ // timer Minute
+};
+// Original
+/* enum {
     PCF8563_CLK_32_768KHZ,
     PCF8563_CLK_1024KHZ,
     PCF8563_CLK_32HZ,
-    PCF8563_CLK_1HZ,
-    PCF8563_CLK_MAX
-};
+    PCF8563_CLK_1HZ
+}; */
 
 uint8_t bcd2dec(uint8_t val);
 uint8_t dec2bcd(uint8_t val);
@@ -63,15 +72,18 @@ esp_err_t pcf8563_get_time(i2c_dev_t *dev, struct tm *time);
 // New functions: Need additional testing
 uint8_t check_err(esp_err_t res, uint8_t * data, uint16_t size, char * op);
 
-uint8_t pcf8563_get_flags(i2c_dev_t *dev);                // Gets and clears Flags
-void pcf8563_set_clock_out(i2c_dev_t *dev, uint8_t mode); // Not tested
-void pcf8563_set_timer(i2c_dev_t *dev, uint8_t val, uint8_t freq); // Sets an interrupt
-void pcf8563_enable_timer(i2c_dev_t *dev);
-esp_err_t pcf8563_enable_clock(i2c_dev_t *dev, uint8_t freq);
+uint8_t pcf8563_get_flags(i2c_dev_t *dev);
+void pcf8563_set_timer(i2c_dev_t *dev, uint8_t freq, uint8_t count); // Sets an interrupt
+void pcf8563_enable_timer(i2c_dev_t *dev); // Needs to be tested
+esp_err_t pcf8563_set_clock_out(i2c_dev_t *dev, uint8_t freq);
+esp_err_t pcf8563_set_clock_out2(i2c_dev_t *dev, uint8_t freq); // Different version from LewisXhe
 
 uint8_t pcf8563_get_timer(i2c_dev_t *dev);
+bool pcf8563_is_timer_active(i2c_dev_t *dev);
 esp_err_t pcf8563_set_alarm(i2c_dev_t *dev, struct tm *time);
 esp_err_t pcf8563_enable_alarm(i2c_dev_t *dev);
+esp_err_t pcf8563_disable_alarm(i2c_dev_t *dev);
+esp_err_t pcf8563_reset_alarm(i2c_dev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/main/pcf8563.h
+++ b/main/pcf8563.h
@@ -11,14 +11,48 @@ extern "C" {
 #include "i2cdev.h"
 
 #define PCF8563_ADDR 0x51 //!< I2C address
-
+// In () https://github.com/lewisxhe/PCF8563_Library/blob/master/src/pcf8563.h
 #define PCF8563_ADDR_STATUS1 0x00
 #define PCF8563_ADDR_STATUS2 0x01
-#define PCF8563_ADDR_TIME    0x02
-#define PCF8563_ADDR_ALARM   0x09
-#define PCF8563_ADDR_CONTROL 0x0d
-#define PCF8563_ADDR_TIMER   0x0e
+#define PCF8563_SEC_REG      0x02
+#define PCF8563_MIN_REG         (0x03)
+#define PCF8563_HR_REG          (0x04)
+#define PCF8563_DAY_REG         (0x05)
+#define PCF8563_WEEKDAY_REG     (0x06)
+#define PCF8563_MONTH_REG       (0x07)
+#define PCF8563_YEAR_REG        (0x08)
+#define PCF8563_ALRM_MIN_REG    (0x09)
+#define PCF8563_SQW_REG         (0x0D)
+#define PCF8563_TIMER1_REG      (0x0E)
+#define PCF8563_TIMER2_REG      (0x0F)
 
+#define PCF8563_VOL_LOW_MASK    (0x80)
+#define PCF8563_minuteS_MASK    (0x7F)
+#define PCF8563_HOUR_MASK       (0x3F)
+#define PCF8563_WEEKDAY_MASK    (0x07)
+#define PCF8563_CENTURY_MASK    (0x80)
+#define PCF8563_DAY_MASK        (0x3F)
+#define PCF8563_MONTH_MASK      (0x1F)
+#define PCF8563_TIMER_CTL_MASK  (0x03)
+
+#define PCF8563_ALARM_AF        (0x08)
+#define PCF8563_TIMER_TF        (0x04)
+#define PCF8563_ALARM_AIE       (0x02)
+#define PCF8563_TIMER_TIE       (0x01)
+#define PCF8563_TIMER_TE        (0x80)
+#define PCF8563_TIMER_TD10      (0x03)
+
+#define PCF8563_NO_ALARM        (0xFF)
+#define PCF8563_ALARM_ENABLE    (0x80)
+#define PCF8563_CLK_ENABLE      (0x80)
+
+enum {
+    PCF8563_CLK_32_768KHZ,
+    PCF8563_CLK_1024KHZ,
+    PCF8563_CLK_32HZ,
+    PCF8563_CLK_1HZ,
+    PCF8563_CLK_MAX
+};
 
 uint8_t bcd2dec(uint8_t val);
 uint8_t dec2bcd(uint8_t val);
@@ -26,6 +60,18 @@ esp_err_t pcf8563_init_desc(i2c_dev_t *dev, i2c_port_t port, gpio_num_t sda_gpio
 esp_err_t pcf8563_reset(i2c_dev_t *dev);
 esp_err_t pcf8563_set_time(i2c_dev_t *dev, struct tm *time);
 esp_err_t pcf8563_get_time(i2c_dev_t *dev, struct tm *time);
+// New functions: Need additional testing
+uint8_t check_err(esp_err_t res, uint8_t * data, uint16_t size, char * op);
+
+uint8_t pcf8563_get_flags(i2c_dev_t *dev);                // Gets and clears Flags
+void pcf8563_set_clock_out(i2c_dev_t *dev, uint8_t mode); // Not tested
+void pcf8563_set_timer(i2c_dev_t *dev, uint8_t val, uint8_t freq); // Sets an interrupt
+void pcf8563_enable_timer(i2c_dev_t *dev);
+esp_err_t pcf8563_enable_clock(i2c_dev_t *dev, uint8_t freq);
+
+uint8_t pcf8563_get_timer(i2c_dev_t *dev);
+esp_err_t pcf8563_set_alarm(i2c_dev_t *dev, struct tm *time);
+esp_err_t pcf8563_enable_alarm(i2c_dev_t *dev);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Check #1
The idea of this PR is to add Timers and Alarm support so we can get INT low (interrupt pin) and also use this RTC for other meaningful things than maintain time (For that is better DS3231) 

Reference libraries

- https://github.com/HausnerR/AVR-PCF8563/blob/master/PCF8563.c
- https://github.com/lewisxhe/PCF8563_Library/tree/master/src note: I don’t trust this library at this point and it’s doing unnecessary read operations that are not really needed. The AVR source looks more appropriate 